### PR TITLE
issue #23 add commands with optional file types

### DIFF
--- a/deploy/deploy/__main__.py
+++ b/deploy/deploy/__main__.py
@@ -26,6 +26,13 @@ class DeployClient(object):
     def base64_command(self, the_base64):
         return the_base64
 
+    @parameter(key="the_base64", type="Base64", optional=True, nullable=True)
+    def base64_command_optional(self, the_base64):
+        if the_base64:
+            return the_base64
+        else:
+            return "no file selected"
+
     @parameter(key="the_bytes", type="Bytes")
     def bytes_command(self, the_bytes):
         return the_bytes

--- a/file-bytes/file_bytes/__main__.py
+++ b/file-bytes/file_bytes/__main__.py
@@ -31,6 +31,13 @@ class FileBytesClient(object):
         """Returns the md5sum of a provided file"""
         return hashlib.md5(some_file).hexdigest()
 
+    def echo_md5sum_optional(self, file_upload):
+        """Returns the md5sum of a provided file"""
+        if file_upload:
+            return hashlib.md5(file_upload).hexdigest()
+        else:
+            return "no file selected"
+
 
 def main():
     p = Plugin(name="file-bytes", version=__version__)


### PR DESCRIPTION
Added commands to `file-bytes` and `deploy` systems for testing requests with optional parameter types of `Base64` and `Bytes`.

## Testing Instructions
- Add or update the `file-bytes` and `deploy` plugins to the plugin directory
- Run commands `base64_command_optional` and `echo_md5sum_optional`

Output of request should be identical to the non-optional version of command when a file is selected and when no file is selected the request will end in an error status until https://github.com/beer-garden/beer-garden/issue/371 is closed.