### PR TITLE
#25 - Remove default instance name from say_specific_from_command_fully_specified

### DIFF
--- a/dynamic/dynamic/__main__.py
+++ b/dynamic/dynamic/__main__.py
@@ -203,7 +203,6 @@ class DynamicClient(object):
                 "command": "get_choices",
                 "system": "dynamic",
                 "version": "1.0.0.dev",
-                "instance_name": "default",
             },
         },
     )


### PR DESCRIPTION
Closes #25 

This PR removes the hard coded instance name from the say_specific_from_command_fully_specified command.  Having that hard coded prevents the command from working, even if you selected an instance in the UI.